### PR TITLE
Development -- Please Read CW3 Hill

### DIFF
--- a/29th_BCT/scripts/gear/blufor_rifleman.sqf
+++ b/29th_BCT/scripts/gear/blufor_rifleman.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "Blufor MTP BLUFOR";
+comment "Blufor Rifleman Loadout";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on 01/24/2018";
 
 _man = _this select 1;
 
@@ -20,39 +21,36 @@ removeHeadgear _man;
 removeGoggles _man;
 
 comment "Add containers";
-_man forceAddUniform "U_B_CombatUniform_mcam";
-_man addItemToUniform "ACE_DefusalKit";
-_man addItemToUniform "ACE_Clacker";
-_man addItemToUniform "ACE_IR_Strobe_Item";
+_man forceAddUniform "rhs_uniform_cu_ocp";
 _man addItemToUniform "ACE_EarPlugs";
-for "_i" from 1 to 10 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 8 do {_man addItemToUniform "ACE_fieldDressing";};
 _man addItemToUniform "ACE_CableTie";
-_man addItemToUniform "ACE_EntrenchingTool";
-for "_i" from 1 to 3 do {_man addItemToUniform "ACE_morphine";};
-_man addItemToUniform "ACE_MapTools";
-_man addItemToUniform "ACE_Flashlight_MX991";
-_man addItemToUniform "SmokeShell";
+for "_i" from 1 to 6 do {_man addItemToUniform "ACE_morphine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "ACE_epinephrine";};
 _man addVest "rhsusf_iotv_ocp_Rifleman";
-_man addItemToVest "rhsusf_ANPVS_15";
-for "_i" from 1 to 2 do {_man addItemToVest "SmokeShell";};
-_man addItemToVest "Chemlight_red";
-for "_i" from 1 to 8 do {_man addItemToVest "rhs_mag_30Rnd_556x45_M855A1_Stanag";};
-_man addItemToVest "rhsusf_mag_15Rnd_9x19_FMJ";
-_man addItemToVest "ACE_HandFlare_White";
+for "_i" from 1 to 7 do {_man addItemToVest "rhs_mag_30Rnd_556x45_M855A1_Stanag";};
 for "_i" from 1 to 3 do {_man addItemToVest "HandGrenade";};
-_man addItemToVest "SmokeShellRed";
-_man addItemToVest "SmokeShellGreen";
+for "_i" from 1 to 3 do {_man addItemToVest "SmokeShell";};
+for "_i" from 1 to 3 do {_man addItemToVest "MiniGrenade";};
+_man addBackpack "rhsusf_assault_eagleaiii_ocp";
+_man addItemToBackpack "rhsusf_ANPVS_15";
+_man addItemToBackpack "ACE_EntrenchingTool";
+_man addItemToBackpack "ACE_Flashlight_MX991";
+_man addItemToBackpack "ACE_IR_Strobe_Item";
+for "_i" from 1 to 2 do {_man addItemToBackpack "rhs_mag_30Rnd_556x45_M855A1_Stanag";};
+_man addItemToBackpack "SmokeShellGreen";
+_man addItemToBackpack "SmokeShellRed";
 _man addHeadgear "rhsusf_ach_helmet_ocp";
 
 comment "Add weapons";
 _man addWeapon "rhs_weap_m4a1";
 _man addPrimaryWeaponItem "rhsusf_acc_compm4";
-_man addWeapon "rhsusf_weap_m9";
-reload _man;
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
-_man linkItem "ItemWatch";
+_man linkItem "tf_microdagr";
+_man linkItem "ItemRadio";
 _man linkItem "ItemGPS";
+

--- a/29th_BCT/scripts/gear/grnfor_ins_rifleman.sqf
+++ b/29th_BCT/scripts/gear/grnfor_ins_rifleman.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "Greenfor INSURGENT GRNFOR";
+comment "Greenfor INSURGENT Rifleman";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on: 01/24/2018";
 
 _man = _this select 1;
 
@@ -20,33 +21,41 @@ removeHeadgear _man;
 removeGoggles _man;
 
 comment "Add containers";
-_man forceAddUniform "rhsgref_uniform_woodland_olive";
+_man forceAddUniform "U_I_C_Soldier_Para_2_F";
 _man addItemToUniform "ACE_EarPlugs";
-for "_i" from 1 to 2 do {_man addItemToUniform "ACE_morphine";};
-for "_i" from 1 to 5 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 8 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 6 do {_man addItemToUniform "ACE_morphine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "ACE_epinephrine";};
 _man addItemToUniform "ACE_CableTie";
 _man addItemToUniform "ACE_Cellphone";
-_man addItemToUniform "Chemlight_blue";
+_man addItemToUniform "ACE_MapTools";
 for "_i" from 1 to 2 do {_man addItemToUniform "SmokeShell";};
-_man addItemToUniform "SmokeShellYellow";
-_man addItemToUniform "rhs_mag_m67";
-_man addItemToUniform "ACE_HandFlare_White";
-_man addVest "rhsgref_6b23_ttsko_mountain_rifleman";
-for "_i" from 1 to 5 do {_man addItemToVest "ACE_fieldDressing";};
-for "_i" from 1 to 6 do {_man addItemToVest "rhs_30Rnd_762x39mm_89";};
-_man addItemToVest "rhs_mag_9x18_8_57N181S";
-_man addHeadgear "H_Bandanna_gry";
-_man addGoggles "rhs_scarf";
+_man addVest "rhs_6b23_6sh116_od";
+for "_i" from 1 to 3 do {_man addItemToVest "rhs_30Rnd_545x39_AK";};
+for "_i" from 1 to 4 do {_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";};
+for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_rgn";};
+for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_rgo";};
+for "_i" from 1 to 3 do {_man addItemToVest "rhs_mag_rdg2_black";};
+_man addBackpack "rhs_sidor";
+_man addItemToBackpack "ACE_Flashlight_XL50";
+_man addItemToBackpack "ACE_Chemlight_Shield";
+_man addItemToBackpack "SmokeShellRed";
+_man addItemToBackpack "SmokeShellBlue";
+_man addItemToBackpack "rhsusf_mag_17Rnd_9x19_JHP";
+_man addItemToBackpack "rhsusf_mag_17Rnd_9x19_FMJ";
+_man addItemToBackpack "rhs_30Rnd_545x39_AK";
+for "_i" from 1 to 2 do {_man addItemToBackpack "rhs_mag_nspd";};
+for "_i" from 1 to 2 do {_man addItemToBackpack "ACE_Chemlight_White";};
+for "_i" from 1 to 2 do {_man addItemToBackpack "ACE_Chemlight_HiYellow";};
+_man addHeadgear "H_Cap_oli";
 
 comment "Add weapons";
-_man addWeapon "rhs_weap_m70ab2";
-_man addWeapon "rhs_weap_makarov_pm";
-reload _man;
+_man addWeapon "rhs_weap_ak74";
+_man addPrimaryWeaponItem "rhs_acc_dtk1983";
+_man addWeapon "rhsusf_weap_glock17g4";
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
-_man linkItem "ItemWatch";
-
-_man addItemToVest "rhs_30Rnd_762x39mm_89";
+_man linkItem "ItemRadio";

--- a/29th_BCT/scripts/gear/grnfor_reg_rifleman.sqf
+++ b/29th_BCT/scripts/gear/grnfor_reg_rifleman.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "Grnfor Woodland GRNFOR";
+comment "Grnfor Regular Rifleman";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on: 01/24/2018";
 
 _man = _this select 1;
 
@@ -20,37 +21,36 @@ removeHeadgear _man;
 removeGoggles _man;
 
 comment "Add containers";
-_man forceAddUniform "rhsgref_uniform_ERDL";
+_man forceAddUniform "rhsgref_uniform_altis_lizard";
 _man addItemToUniform "ACE_EarPlugs";
-for "_i" from 1 to 10 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 8 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 6 do {_man addItemToUniform "ACE_morphine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "ACE_epinephrine";};
 _man addItemToUniform "ACE_CableTie";
-for "_i" from 1 to 2 do {_man addItemToUniform "ACE_morphine";};
-_man addItemToUniform "ACE_Chemlight_Shield";
-_man addItemToUniform "ACE_Flashlight_MX991";
-_man addItemToUniform "ACE_HandFlare_White";
-_man addItemToUniform "rhsusf_mag_17Rnd_9x19_FMJ";
 for "_i" from 1 to 2 do {_man addItemToUniform "SmokeShell";};
-_man addItemToUniform "SmokeShellGreen";
-_man addItemToUniform "Chemlight_green";
+_man addItemToUniform "rhsusf_mag_17Rnd_9x19_FMJ";
 _man addVest "rhsgref_6b23_khaki_rifleman";
-_man addItemToVest "rhs_1PN138";
-for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_m67";};
-for "_i" from 1 to 7 do {_man addItemToVest "rhsgref_30rnd_556x45_m21";};
-_man addItemToVest "rhsgref_30rnd_556x45_m21_t";
-_man addHeadgear "rhsgref_helmet_pasgt_woodland";
+for "_i" from 1 to 6 do {_man addItemToVest "rhs_30Rnd_762x39mm_Savz58";};
+_man addItemToVest "rhs_mag_rgn";
+_man addItemToVest "rhs_mag_rgo";
+_man addBackpack "rhs_sidor";
+_man addItemToBackpack "ACE_Flashlight_MX991";
+_man addItemToBackpack "rhs_1PN138";
+_man addItemToBackpack "SmokeShellRed";
+_man addItemToBackpack "SmokeShellBlue";
+_man addItemToBackpack "rhsusf_mag_17Rnd_9x19_JHP";
+_man addItemToBackpack "rhsusf_mag_17Rnd_9x19_FMJ";
+_man addItemToBackpack "rhs_mag_rgn";
+_man addItemToBackpack "rhs_mag_rgo";
+_man addHeadgear "rhsgref_helmet_pasgt_altis_lizard";
 
 comment "Add weapons";
-_man addWeapon "rhs_weap_m21a";
-_man addPrimaryWeaponItem "rhsusf_acc_SF3P556";
-_man addPrimaryWeaponItem "rhs_acc_perst1ik";
+_man addWeapon "rhs_weap_savz58p_black";
 _man addWeapon "rhsusf_weap_glock17g4";
-reload _man;
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
-_man linkItem "ItemWatch";
+_man linkItem "ItemRadio";
 _man linkItem "ItemGPS";
-
-_man addItemToVest "rhsgref_30rnd_556x45_m21";

--- a/29th_BCT/scripts/gear/opfor_des_rifleman.sqf
+++ b/29th_BCT/scripts/gear/opfor_des_rifleman.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "Opfor Desert OPFOR";
+comment "Opfor Desert Rifleman";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on: 01/24/2018";
 
 _man = _this select 1;
 
@@ -21,39 +22,31 @@ removeGoggles _man;
 
 comment "Add containers";
 _man forceAddUniform "rhs_uniform_emr_des_patchless";
-_man addItemToUniform "ACE_DefusalKit";
-_man addItemToUniform "ACE_Clacker";
-_man addItemToUniform "ACE_IR_Strobe_Item";
 _man addItemToUniform "ACE_EarPlugs";
-for "_i" from 1 to 10 do {_man addItemToUniform "ACE_fieldDressing";};
-_man addItemToUniform "ACE_CableTie";
-_man addItemToUniform "ACE_EntrenchingTool";
-for "_i" from 1 to 3 do {_man addItemToUniform "ACE_morphine";};
-_man addItemToUniform "ACE_MapTools";
-_man addItemToUniform "ACE_Flashlight_KSF1";
-_man addItemToUniform "SmokeShell";
+for "_i" from 1 to 8 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 6 do {_man addItemToUniform "ACE_morphine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "ACE_epinephrine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "rhs_mag_rdg2_black";};
 _man addVest "rhs_6b23_6sh116";
-_man addItemToVest "rhs_1PN138";
-for "_i" from 1 to 7 do {_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";};
-for "_i" from 1 to 3 do {_man addItemToVest "rhs_mag_rgd5";};
+for "_i" from 1 to 8 do {_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";};
+for "_i" from 1 to 4 do {_man addItemToVest "rhs_mag_rgd5";};
 _man addItemToVest "rhs_mag_rdg2_black";
-_man addItemToVest "ACE_HandFlare_White";
-for "_i" from 1 to 2 do {_man addItemToVest "SmokeShell";};
-_man addItemToVest "Chemlight_red";
-_man addItemToVest "rhs_mag_9x19_17";
-_man addHeadgear "rhs_6b7_1m_olive";
+for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_9x19_17";};
+_man addBackpack "rhs_assault_umbts";
+_man addItemToBackpack "rhs_1PN138";
+_man addItemToBackpack "ACE_CableTie";
+_man addItemToBackpack "ACE_EntrenchingTool";
+_man addItemToBackpack "ACE_Flashlight_XL50";
+_man addHeadgear "rhs_6b7_1m";
 
 comment "Add weapons";
 _man addWeapon "rhs_weap_ak74m";
-_man addPrimaryWeaponItem "rhs_acc_dtk";
 _man addWeapon "rhs_weap_pya";
-reload _man;
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
 _man linkItem "tf_microdagr";
+_man linkItem "ItemRadio";
 _man linkItem "ItemGPS";
-
-_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";

--- a/29th_BCT/scripts/gear/opfor_wd_rifleman.sqf
+++ b/29th_BCT/scripts/gear/opfor_wd_rifleman.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "Opfor Summer OPFOR";
+comment "Opfor Summer Rifleman";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on: 01/24/2018";
 
 _man = _this select 1;
 
@@ -21,39 +22,32 @@ removeGoggles _man;
 
 comment "Add containers";
 _man forceAddUniform "rhs_uniform_emr_patchless";
-_man addItemToUniform "ACE_DefusalKit";
-_man addItemToUniform "ACE_Clacker";
-_man addItemToUniform "ACE_IR_Strobe_Item";
 _man addItemToUniform "ACE_EarPlugs";
-for "_i" from 1 to 10 do {_man addItemToUniform "ACE_fieldDressing";};
-_man addItemToUniform "ACE_CableTie";
-_man addItemToUniform "ACE_EntrenchingTool";
-for "_i" from 1 to 3 do {_man addItemToUniform "ACE_morphine";};
-_man addItemToUniform "ACE_MapTools";
-_man addItemToUniform "ACE_Flashlight_KSF1";
-_man addItemToUniform "SmokeShell";
+for "_i" from 1 to 8 do {_man addItemToUniform "ACE_fieldDressing";};
+for "_i" from 1 to 6 do {_man addItemToUniform "ACE_morphine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "ACE_epinephrine";};
+for "_i" from 1 to 2 do {_man addItemToUniform "rhs_mag_rdg2_black";};
 _man addVest "rhs_6b23_6sh116";
-_man addItemToVest "rhs_1PN138";
-for "_i" from 1 to 7 do {_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";};
-for "_i" from 1 to 3 do {_man addItemToVest "rhs_mag_rgd5";};
+for "_i" from 1 to 8 do {_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";};
+for "_i" from 1 to 4 do {_man addItemToVest "rhs_mag_rgd5";};
 _man addItemToVest "rhs_mag_rdg2_black";
-_man addItemToVest "ACE_HandFlare_White";
-for "_i" from 1 to 2 do {_man addItemToVest "SmokeShell";};
-_man addItemToVest "Chemlight_red";
-_man addItemToVest "rhs_mag_9x19_17";
+for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_9x19_17";};
+_man addBackpack "rhs_assault_umbts";
+_man addItemToBackpack "rhs_1PN138";
+_man addItemToBackpack "ACE_CableTie";
+_man addItemToBackpack "ACE_EntrenchingTool";
+_man addItemToBackpack "ACE_Flashlight_XL50";
 _man addHeadgear "rhs_6b7_1m_emr";
 
 comment "Add weapons";
 _man addWeapon "rhs_weap_ak74m";
 _man addPrimaryWeaponItem "rhs_acc_dtk";
 _man addWeapon "rhs_weap_pya";
-reload _man;
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
 _man linkItem "tf_microdagr";
+_man linkItem "ItemRadio";
 _man linkItem "ItemGPS";
-
-_man addItemToVest "rhs_30Rnd_545x39_7N22_AK";

--- a/29th_BCT/scripts/gear/parade.sqf
+++ b/29th_BCT/scripts/gear/parade.sqf
@@ -1,7 +1,8 @@
 comment "29th Infantry Division";
-comment "PARADE BLUERFOR";
+comment "Parade Loadout";
 comment "Requires ACE3, RHS, and 29th mod";
 comment "Designed for Basic medical settings";
+comment "Updated on: 01/24/2018";
 
 _man = _this select 1;
 
@@ -20,20 +21,20 @@ removeHeadgear _man;
 removeGoggles _man;
 
 comment "Add containers";
-_man forceAddUniform "U_B_CombatUniform_mcam";
-for "_i" from 1 to 4 do {_man addItemToUniform "rhs_mag_30Rnd_556x45_M855A1_Stanag";};
+_man forceAddUniform "rhs_uniform_cu_ocp";
+for "_i" from 1 to 3 do {_man addItemToUniform "rhs_mag_30Rnd_556x45_M855_Stanag";};
 _man addVest "rhsusf_iotv_ocp";
-for "_i" from 1 to 3 do {_man addItemToVest "ACE_fieldDressing";};
-_man addItemToVest "ACE_morphine";
-for "_i" from 1 to 2 do {_man addItemToVest "rhs_mag_30Rnd_556x45_M855A1_Stanag";};
-_man addHeadgear "29th_Helmet";
+for "_i" from 1 to 6 do {_man addItemToVest "ACE_fieldDressing";};
+for "_i" from 1 to 4 do {_man addItemToVest "ACE_morphine";};
+_man addHeadgear "rhsusf_patrolcap_ocp";
 
 comment "Add weapons";
-_man addWeapon "rhs_weap_m16a4_carryhandle";
+_man addWeapon "rhs_weap_m4a1";
 _man addWeapon "Binocular";
 
 comment "Add items";
 _man linkItem "ItemMap";
 _man linkItem "ItemCompass";
 _man linkItem "ItemWatch";
+_man linkItem "ItemRadio";
 _man linkItem "ItemGPS";

--- a/29th_Training_Mission_Template/_Mission Files/functions/29th_Training/CfgFunctions.hpp
+++ b/29th_Training_Mission_Template/_Mission Files/functions/29th_Training/CfgFunctions.hpp
@@ -11,5 +11,6 @@ class 29th_Training {
     class handleInitialInventory {};
     class noThermals {};
     class adjustRating {};
+    //class activateAddons {preInit = 1;};
   };
 };

--- a/29th_Training_Mission_Template/_Mission Files/functions/29th_Training/fn_activateAddons.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/functions/29th_Training/fn_activateAddons.sqf
@@ -1,0 +1,20 @@
+if (isServer) then {
+  diag_log text "Adding Mandatory Addons";
+//  ["29th_Insignias"] call BIS_fnc_activateAddons;
+//if !(isserver) exitwith {"The function can be called only on server." call bis_fnc_error; []};
+//if (time > 0) exitwith {"The function can be activated only during the mission init." call bis_fnc_error; []};
+
+  private ["_input","_addons"];
+  _input = ["29th_Insignias"];
+  _addons = activatedaddons;
+  {
+    private ["_addon"];
+    _addon = _x param [0,"",[""]];
+    _addon = if (isclass (configfile >> "cfgpatches" >> _addon)) then {[_addon]} else {unitaddons _addon};
+      {
+        if !(_x in _addons) then {_addons set [count _addons,_x];};
+      } foreach _addon;
+  } foreach _input;
+  activateaddons _addons;
+  _addons
+};

--- a/29th_Training_Mission_Template/_Mission Files/initPlayerLocal.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/initPlayerLocal.sqf
@@ -25,7 +25,7 @@ if (artilleryComputer == 0) then {
 // ==============================================================================
 
 [_theClient] execVM "scripts\player_arsenal_handlers.sqf";
-_theClient addEventHandler ["Respawn",{_this select 0 spawn Hill_fnc_setInsignia;}]
+_theClient addEventHandler ["Respawn", {_this select 0 spawn Hill_fnc_setInsignia;}];
 
 [_theClient] spawn {
  private _theClient = _this select 0;

--- a/29th_Training_Mission_Template/_Mission Files/initPlayerLocal.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/initPlayerLocal.sqf
@@ -25,6 +25,7 @@ if (artilleryComputer == 0) then {
 // ==============================================================================
 
 [_theClient] execVM "scripts\player_arsenal_handlers.sqf";
+_theClient addEventHandler ["Respawn",{_this select 0 spawn Hill_fnc_setInsignia;}]
 
 [_theClient] spawn {
  private _theClient = _this select 0;

--- a/29th_Training_Mission_Template/_Mission Files/initServer.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/initServer.sqf
@@ -3,6 +3,8 @@ Executed only on server when mission is started.
 */
 diag_log text format ["|=============================   %1: initServer.sqf Running   =============================|", missionName];
 
+INDEPENDENT setFriend [WEST, 0];
+
 if (count (entities "HeadlessClient_F") > 0) then {
 	systemChat "Headless Client is online. Spawned units will be transferred to the HC.";
 	hc_online = true;

--- a/29th_Training_Mission_Template/_Mission Files/onPlayerRespawn.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/onPlayerRespawn.sqf
@@ -10,27 +10,27 @@ _oldUnit = _this select 1;
 
 _side = side (group _oldUnit);
 
-_newUnit spawn Hill_fnc_setInsignia;
+if (isNull _oldUnit) then {
+  _newUnit spawn Hill_fnc_setInsignia;
 
-//[_newUnit] call Hill_fnc_playerAdmin;
+//  [_newUnit] call Hill_fnc_playerAdmin;
 
-/*if (isNil "autoSpectate") then {
-	[] spawn
-		{
-			waitUntil {!isNil "autoSpectate"};
-			player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_ON_ca.paa'/><t color='#00FFFF'>  Enable Auto Spectate</t>",{autoSpectate = true;publicVariable "autoSpectate";systemChat "AutoSpectate is ON.";},"alpha",-999,false,true,"","(!autoSpectate && _target == _this && _target == theMan)"];
-			player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_OFF_ca.paa'/><t color='#00FFFF'>  Disable Auto Spectate</t>",{autoSpectate = false;publicVariable "autoSpectate";systemChat "AutoSpectate is OFF.";},"alpha",-999,false,true,"","(autoSpectate && _target == _this && _target == theMan)"];
-		};
-} else {
-	player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_ON_ca.paa'/><t color='#00FFFF'>  Enable Auto Spectate</t>",{autoSpectate = true;publicVariable "autoSpectate";systemChat "AutoSpectate is ON.";},"alpha",-97,false,true,"","(!autoSpectate && _target == _this && _target == theMan)"];
-	player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_OFF_ca.paa'/><t color='#00FFFF'>  Disable Auto Spectate</t>",{autoSpectate = false;publicVariable "autoSpectate";systemChat "AutoSpectate is OFF.";},"alpha",-97,false,true,"","(autoSpectate && _target == _this && _target == theMan)"];
-};*/
+/*  if (isNil "autoSpectate") then {
+      [] spawn {
+        waitUntil {!isNil "autoSpectate"};
+        player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_ON_ca.paa'/><t color='#00FFFF'>  Enable Auto Spectate</t>",{autoSpectate = true;publicVariable "autoSpectate";systemChat "AutoSpectate is ON.";},"alpha",-999,false,true,"","(!autoSpectate && _target == _this && _target == theMan)"];
+        player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_OFF_ca.paa'/><t color='#00FFFF'>  Disable Auto Spectate</t>",{autoSpectate = false;publicVariable "autoSpectate";systemChat "AutoSpectate is OFF.";},"alpha",-999,false,true,"","(autoSpectate && _target == _this && _target == theMan)"];
+      };
+    } else {
+      player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_ON_ca.paa'/><t color='#00FFFF'>  Enable Auto Spectate</t>",{autoSpectate = true;publicVariable "autoSpectate";systemChat "AutoSpectate is ON.";},"alpha",-97,false,true,"","(!autoSpectate && _target == _this && _target == theMan)"];
+      player addAction ["<img image='\A3\Ui_f\data\IGUI\Cfg\Actions\ico_OFF_ca.paa'/><t color='#00FFFF'>  Disable Auto Spectate</t>",{autoSpectate = false;publicVariable "autoSpectate";systemChat "AutoSpectate is OFF.";},"alpha",-97,false,true,"","(autoSpectate && _target == _this && _target == theMan)"];
+    };*/
+};
 
 if !(isNull _oldUnit) then {
-//		enableEnvironment false;
-	//{_x addCuratorEditableObjects [[player],false];} count allCurators;  // Add player back to Zeus(s)
-//	[ _newUnit, [ missionNamespace, "currentInventory" ] ] call BIS_fnc_loadInventory; // load player's inventory
-	_newUnit spawn Hill_fnc_setInsignia;
+//  enableEnvironment false;
+//  {_x addCuratorEditableObjects [[player],false];} count allCurators;  // Add player back to Zeus(s)
+//  [ _newUnit, [ missionNamespace, "currentInventory" ] ] call BIS_fnc_loadInventory; // load player's inventory
 	if ( missionNamespace getVariable [ "menuRespawn", true ] ) then {
 		if (autoSpectate) then {
 			systemChat "AutoSpectate is ON.";

--- a/29th_Training_Mission_Template/_Mission Files/scripts/excludeObjFromZeus.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/scripts/excludeObjFromZeus.sqf
@@ -24,6 +24,9 @@ curatorExcludedObjects = [] spawn {
 				} forEach allCurators;
 			};
 		} forEach _excluded;
+    if (count _editableObjects > 1000) then {
+      _editableObjects = [];
+    };
 		sleep 3;
 	};
 };

--- a/29th_Training_Mission_Template/_Mission Files/scripts/init_curators.sqf
+++ b/29th_Training_Mission_Template/_Mission Files/scripts/init_curators.sqf
@@ -31,27 +31,58 @@ if (isClass (configFile >> "CfgPatches" >> "ace_main")) then {
 };
 
 if (isNil "hc_online") then {
-  waitUntil {!isNil "hc_online"};
-
+  [] spawn {
+    waitUntil {!isNil "hc_online"};
+    if (hc_online) then {
+      {
+        //Move curator placed units to the headless client
+        AIswitchToHC = _x addEventHandler ["CuratorGroupPlaced", {
+          private ["_grp_entity", "_numUnits"];
+          _grp_entity = _this select 1;
+          _numUnits = count (units _grp_entity);
+          missionNamespace setVariable ["BIS_fps_rescanNewObjects", true];
+          if (groupOwner _grp_entity != owner "Headless Client") then {
+            _grp_entity setGroupOwner (owner "Headless Client");
+            systemChat format ["%1 units moved to HC.", _numUnits];
+          };
+        }];
+      } forEach allCurators;
+    };
+    if (!hc_online) then {
+      {
+		    //Move curator placed units to the server
+        AIswitchToServer = _x addEventHandler ["CuratorGroupPlaced", {
+          private ["_grp_entity", "_numUnits"];
+          _grp_entity = _this select 1;
+          _numUnits = count (units _grp_entity);
+          missionNamespace setVariable ["BIS_fps_rescanNewObjects", true];
+          if (groupOwner _grp_entity != 2) then {
+            _grp_entity setGroupOwner 2;
+            systemChat format ["%1 units moved to server.", _numUnits];
+          };
+        }];
+      } forEach allCurators;
+    };
+  };
+} else {
   if (hc_online) then {
     {
-// 		Move curator placed units to the headless client
+      //Move curator placed units to the headless client
       AIswitchToHC = _x addEventHandler ["CuratorGroupPlaced", {
         private ["_grp_entity", "_numUnits"];
         _grp_entity = _this select 1;
         _numUnits = count (units _grp_entity);
         missionNamespace setVariable ["BIS_fps_rescanNewObjects", true];
-        if (groupOwner _grp_entity != owner "Headless Client") then {
+         if (groupOwner _grp_entity != owner "Headless Client") then {
           _grp_entity setGroupOwner (owner "Headless Client");
           systemChat format ["%1 units moved to HC.", _numUnits];
         };
       }];
     } forEach allCurators;
   };
-	
   if (!hc_online) then {
     {
-//		  Move curator placed units to the server
+		  //Move curator placed units to the server
       AIswitchToServer = _x addEventHandler ["CuratorGroupPlaced", {
         private ["_grp_entity", "_numUnits"];
         _grp_entity = _this select 1;
@@ -64,15 +95,28 @@ if (isNil "hc_online") then {
       }];
     } forEach allCurators;
   };
-
 };
 
 if (isNil "disabledTI") then {
-  waitUntil {!isNil "disabledTI"};
-  
+  [] spawn {
+    waitUntil {!isNil "disabledTI"};
+    if (disabledTI == 0) then {
+      {
+        //Call ACE3 Fast Rope function on each helicopter placed
+        disableThermalImaging = _x addEventHandler ["CuratorObjectPlaced", {
+          private ["_objectPlaced"];
+          _objectPlaced = _this select 1;
+          if (_objectPlaced isKindOf "Air" || _objectPlaced isKindOf "Car" || _objectPlaced isKindOf "Ship" || _objectPlaced isKindOf "Tank" || _objectPlaced isKindOf "StaticWeapon") then {
+            _objectPlaced disableTIEquipment true;
+          };
+        }];
+      } forEach allCurators;
+    };
+  };
+} else {
   if (disabledTI == 0) then {
     {
-		//  Call ACE3 Fast Rope function on each helicopter placed
+      //Call ACE3 Fast Rope function on each helicopter placed
       disableThermalImaging = _x addEventHandler ["CuratorObjectPlaced", {
         private ["_objectPlaced"];
         _objectPlaced = _this select 1;
@@ -82,9 +126,7 @@ if (isNil "disabledTI") then {
       }];
     } forEach allCurators;
   };
-
 };
-
 /*
 //	Used with Stats system
 {


### PR DESCRIPTION
ALL CHANGES MADE TO: **BCT Mission**
Updated the BCT Loadouts obtained via the addAction on editor placed Virtual Arsenals.
**!!NOTE!!** The second commit I updated the remainder of the Loadouts.
So all addAction BCT Loadouts are now up to date with Current 29th Rifleman Loadout Standards for All Factions. (Blufor Parade, Blufor Rifleman, Opfor Woodland, Opfor Desert, Grnfor Regular, Grnfor Insurgent)


In case we decide to switch from the Virtual Arsenal to the ACE Arsenal in the BCT Mission, I created Public Loadouts of  _Parade, Blufor Rifleman, Opfor Woodland Rifleman, Opfor Desert Rifleman, Grnfor Insurgent Rifleman, and Grnfor Regular Rifleman_.
That way upon passing the POA and Day 5 of BCT, I can have them just access the Public Loadouts and Save them right away in the ACE Arsenal so they are all set with loadouts directly out of BCT.